### PR TITLE
Remove an old, unused web3 provider

### DIFF
--- a/tool/maian.py
+++ b/tool/maian.py
@@ -21,7 +21,7 @@ SOFTWARE.
 '''
 
 from __future__ import print_function
-from web3 import Web3, KeepAliveRPCProvider, IPCProvider
+from web3 import Web3, IPCProvider
 import argparse,subprocess,sys
 
 


### PR DESCRIPTION
KeepAliveRPCProvider was removed in newer versions of web3.py, so importing it here causes a crash. It seems to be unused, so it's a simple fix. Several people reported this issue in: https://github.com/ethereum/web3.py/issues/879